### PR TITLE
Call Scanorama directly from R

### DIFF
--- a/script/data_integration/RNA_mix/cellBench_RNAmix_integration.R
+++ b/script/data_integration/RNA_mix/cellBench_RNAmix_integration.R
@@ -52,6 +52,9 @@ library(scRNAseq)  # to extract weights in zinbwave
 
 library(scMerge)
 
+library(reticulate)
+scanorama <- import('scanorama')
+
 library(kBET)
 
 library(cluster) # to calculate silhouette and ARI
@@ -399,11 +402,11 @@ ggplot(data.plot, aes(x = comp1, y = comp2, shape = factor(mix.type))) + geom_po
 
 
 ## ---- eval = eval_code---------------------------------------------------
-## # data available for upload (in python)
-## data.scanorama = read.csv('Data/scanorama-merged_cel-sort.csv', header = TRUE, row.names = 1)
-## #dim(data.scanorama)
+## scanorama.corrected = scanorama$correct(list(t(logcounts(CELseq.norm)[high.var.genes.scran,]), t(logcounts(SORTseq.norm)[high.var.genes.scran,])), list(high.var.genes.scran, high.var.genes.scran), return_dense = TRUE)
 ## 
-## pca.scanorama = mixOmics::pca(t(data.scanorama), ncomp = 2)
+## data.scanorama = Reduce(rbind, scanorama.corrected[[1]])
+## 
+## pca.scanorama = mixOmics::pca(data.scanorama, ncomp = 2)
 
 ## ----scanorama-----------------------------------------------------------
 # color indicates protocol

--- a/script/data_integration/cell_mix/CellBench_puremix_integration.R
+++ b/script/data_integration/cell_mix/CellBench_puremix_integration.R
@@ -52,6 +52,9 @@ library(scRNAseq)  # to extract weights in zinbwave
 
 library(scMerge)
 
+library(reticulate)
+scanorama <- import('scanorama')
+
 library(kBET)
 
 library(cluster) # to calculate silhouette and ARI
@@ -391,15 +394,15 @@ ggplot(data.plot, aes(x = comp1, y = comp2, shape = factor(cell.line))) + geom_p
 ##                 shape_by = "cell")
 
 ## ---- eval = eval_code---------------------------------------------------
-## # data available for upload (in python)
-## data.scanorama = read.csv('Data/scanorama_merged_cellbench.csv', header = TRUE, row.names = 1)
-## #dim(data.scanorama)
+## scanorama.corrected = scanorama$correct(list(t(logcounts(sc10x.norm)[high.var.genes.scran,]), t(logcounts(sccel.norm)[high.var.genes.scran,]), t(logcounts(scdrop.norm)[high.var.genes.scran,])), list(high.var.genes.scran, high.var.genes.scran, high.var.genes.scran), return_dense = TRUE)
 ## 
-## pca.scanorama = mixOmics::pca(t(data.scanorama), ncomp = 2)
+## data.scanorama = Reduce(rbind, scanorama.corrected[[1]])
+## 
+## pca.scanorama = mixOmics::pca(data.scanorama, ncomp = 2)
 
 ## ----scanorama-----------------------------------------------------------
 # color indicates protocol
-plotIndiv(pca.scanorama, pch = cell.line, ind.names =FALSE, group = batch, legend = FALSE, legend.title = 'Protocol', legend.title.pch = 'Cell line', title = 'Scanorama', xlim = c(-0.2, 0.2), ylim = c(-0.2, 0.2))
+plotIndiv(pca.scanorama, pch = cell.line, ind.names =FALSE, group = batch, legend = FALSE, legend.title = 'Protocol', legend.title.pch = 'Cell line', title = 'Scanorama', xlim = c(-0.4, 0.4), ylim = c(-0.3, 0.3))
 
 ## ---- eval = eval_code---------------------------------------------------
 ## # on original data


### PR DESCRIPTION
Hello @LuyiTian,

I've been trying to reproduce some of the integration results and have made some changes that I think will help make for a more fair comparison between the R packages and Scanorama (written in Python), as well as helping others with reproducibility of these scripts!

In particular, these changes directly call Scanorama from R and avoid potential weirdness/bugs caused from, for example, trying to run Scanorama in Python and trying to do some conversion to R.

I'm not sure about how Scanorama was originally being used, but when using Scanorama directly from these scripts it seems to perform much better than originally reported, e.g., for the cell_mix experiments:

<img src="https://user-images.githubusercontent.com/6365340/46586349-4e4fa300-ca4b-11e8-8f33-47c951d6e598.png" width="250px" /> <img src="https://user-images.githubusercontent.com/6365340/46586352-560f4780-ca4b-11e8-9b58-4b5f8932cde9.png" width="250px" />

And for the RNA_mix experiments:

<img src="https://user-images.githubusercontent.com/6365340/46586354-5f98af80-ca4b-11e8-89a4-3cbe6442c1b2.png" width="250px" /> <img src="https://user-images.githubusercontent.com/6365340/46586357-64f5fa00-ca4b-11e8-91f3-a73719e6bad2.png" width="250px" />

**Replication instructions**

The changes should be minimal and require only a few additional dependencies.  First, you'll need the latest version of Scanorama (>=0.3) from here: https://github.com/brianhie/scanorama
Just clone into the repo and install with
```
python setup.py install --user
```

Then, you'll need to install R's reticulate package:
```
install.packages('reticulate')
```

Then you should be good to go!